### PR TITLE
change CharView.html bundle from main to classForCoder to find correct path when the project is outside the main

### DIFF
--- a/AAInfographics/AAChartCreator/AAChartView.swift
+++ b/AAInfographics/AAChartCreator/AAChartView.swift
@@ -223,9 +223,10 @@ extension AAChartView {
     public func aa_drawChartWithChartModel(_ chartModel: AAChartModel) {
         if optionsJson == nil {
             configureTheJavaScriptString(chartModel)
-            let path = Bundle.main.path(forResource: "AAChartView",
-                                        ofType: "html",
-                                        inDirectory: "AAJSFiles.bundle")
+            let path = Bundle(for: self.classForCoder)
+                .path(forResource: "AAChartView",
+                      ofType: "html",
+                      inDirectory: "AAJSFiles.bundle")
             let urlStr = NSURL.fileURL(withPath: path!)
             let urlRequest = NSURLRequest(url: urlStr) as URLRequest
             if #available(iOS 9.0, *) {


### PR DESCRIPTION
If bundle are always the main, when any developer include this project with cocoaPod(For exemple), the bundle of "AAInfographics" isn't the main. That commit solves this problem.