### PR TITLE
add the marginBottom property for AAChartModel

### DIFF
--- a/AAInfographics/AAChartCreator/AAChartModel.swift
+++ b/AAInfographics/AAChartCreator/AAChartModel.swift
@@ -175,6 +175,7 @@ public class AAChartModel: AASerializable {
     public var titleColor: String?          //标题颜色
     public var subtitleColor: String?       //副标题颜色
     public var axisColor: String?           //x 轴和 y 轴文字颜色
+    private var marginBottom: Float?
     
     
     @discardableResult
@@ -411,6 +412,11 @@ public class AAChartModel: AASerializable {
         return self
     }
     
+    @discardableResult
+    public func marginBottom(_ prop: Float) -> AAChartModel {
+        marginBottom = prop
+        return self
+    }
     
     public init() {
         backgroundColor     = "#ffffff"

--- a/AAInfographics/AAChartCreator/AAOptionsConstructor.swift
+++ b/AAInfographics/AAChartCreator/AAOptionsConstructor.swift
@@ -44,6 +44,7 @@ public class AAOptionsConstructor: NSObject {
         aaChart.setValue(aaChartModel.polar, forKey: "polar")//是否辐射化图形
         aaChart.setValue(aaChartModel.marginLeft, forKey: "marginLeft")
         aaChart.setValue(aaChartModel.marginRight, forKey: "marginRight")
+        aaChart.setValue(aaChartModel.marginBottom, forKey: "marginBottom")
         
         let aaTitle = NSMutableDictionary()
         aaTitle.setValue(aaChartModel.title, forKey: "text")//标题文本内容


### PR DESCRIPTION
adding marginBottom property for AAChartModel, it's useful in some cases, for exemple the bug on [#102](https://github.com/AAChartModel/AAChartKit-Swift/issues/102), when the chartModel doesn't respect the size on older devices(probably related to the old Safari interpreter)