### PR TITLE
Fixed javascript error caused by extra trailing parenthesis

### DIFF
--- a/AAInfographics/AAChartCreator/AAChartView.swift
+++ b/AAInfographics/AAChartCreator/AAChartView.swift
@@ -476,7 +476,7 @@ extension AAChartView {
         }
         let finalJSArrStr = "[\(originalJsArrStr)]"
         
-        let jsFunctionStr = "aaGlobalChart.xAxis[0].setCategories(\(finalJSArrStr),\(redraw));)"
+        let jsFunctionStr = "aaGlobalChart.xAxis[0].setCategories(\(finalJSArrStr),\(redraw));"
         safeEvaluateJavaScriptString(jsFunctionStr)
     }
     


### PR DESCRIPTION
When calling func `aa_updateXAxisCategories` in `AAChartView`, an extra trailing parenthesis in `jsFunctionStr` was causing a JS error when calling `safeEvaluateJavaScriptString`.