### PR TITLE
- Crash fixed

### DIFF
--- a/AAInfographics/AAChartCreator/AAChartView.swift
+++ b/AAInfographics/AAChartCreator/AAChartView.swift
@@ -283,6 +283,7 @@ public class AAChartView: WKWebView {
     }
     
     private func addMouseOverEventMessageHandler() {
+        configuration.userContentController.removeScriptMessageHandler(forName: kUserContentMessageNameMouseOver)
         configuration.userContentController.add(AALeakAvoider.init(delegate: self), name: kUserContentMessageNameMouseOver)
     }
     


### PR DESCRIPTION
NSInvalidArgumentException - Attempt to add script message handler with name 'mouseover' when one already exists.