### PR TITLE
Update AASerializable.swift

### DIFF
--- a/AAInfographics/AAChartCreator/AASerializable.swift
+++ b/AAInfographics/AAChartCreator/AASerializable.swift
@@ -34,11 +34,9 @@ import Foundation
 
 open class AAObject {
     public init() {}
-}
 
-@available(iOS 10.0, macCatalyst 13.1, macOS 10.13, *)
-public extension AAObject {
-    var classNameString: String {
+    @available(iOS 10.0, macCatalyst 13.1, macOS 10.13, *)
+    open var classNameString: String {
         let nameClass: AnyClass! = object_getClass(self)
         return NSStringFromClass(nameClass)
     }


### PR DESCRIPTION
使用 Extension 兼容性较差，目前类必须同名且如果将类设置为 private。取出来的也是错误的类名。修改后支持外面自定义